### PR TITLE
Change definition of `stdDate`

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -13,7 +13,7 @@ export const MINYEAR = 1
 export const MAXYEAR = 9999
 
 
-const stdDate = Function('return this')().Date;
+const stdDate = globalThis.Date;
 
 
 /**


### PR DESCRIPTION
Not sure what the original intention was, but this way there is no `eval` magic going on. I've run into this issue specifically when using [deno deploy](https://deno.com/deploy) which doesn't allow `eval` or `Function` to be ran on the cloud. 